### PR TITLE
Migrate from Laravel Mix to Vite

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
         ports:
             - '${APP_PORT:-80}:80'
             - '${VITE_PORT:-5173}:${VITE_PORT:-5173}'
+            - '${VITE_PORT:-5173}:${VITE_PORT:-5173}'
             - '${LARAVEL_WEBSOCKETS_PORT:-6001}:6001'
         environment:
             WWWUSER: '${WWWUSER}'

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "private": true,
     "scripts": {
         "dev": "vite",
-        "build": "vite build && vite build --ssr"
+        "build": "vite build"
     },
     "devDependencies": {
         "@inertiajs/vue3": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -8,17 +8,17 @@
         "@inertiajs/vue3": "^1.0.0",
         "@tailwindcss/forms": "^0.5.2",
         "@tailwindcss/typography": "^0.5.2",
-        "@vitejs/plugin-vue": "^4.0.0",
+        "@vitejs/plugin-vue": "^3.0.1",
         "@vue/server-renderer": "^3.2.31",
         "autoprefixer": "^10.4.7",
         "axios": "^1.1.2",
         "laravel-echo": "^1.15.0",
-        "laravel-vite-plugin": "^0.7.2",
+        "laravel-vite-plugin": "^0.6.0",
         "lodash": "^4.17.19",
         "postcss": "^8.4.14",
         "pusher-js": "^8.0.1",
         "tailwindcss": "^3.1.0",
-        "vite": "^4.0.0",
+        "vite": "^3.0.2",
         "vue": "^3.2.31"
     }
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,21 +1,11 @@
 import { defineConfig } from 'vite';
 import laravel from 'laravel-vite-plugin';
-import vue from '@vitejs/plugin-vue';
 
 export default defineConfig({
     plugins: [
         laravel({
-            input: 'resources/js/app.js',
-            ssr: 'resources/js/ssr.js',
+            input: ['resources/css/app.css', 'resources/js/app.js'],
             refresh: true,
         }),
-        vue({
-            template: {
-                transformAssetUrls: {
-                    base: null,
-                    includeAbsolute: false,
-                },
-            },
-        }),
-    ],  
+    ],
 });


### PR DESCRIPTION
This pull request includes changes for migrating from Laravel Mix to Vite outlined in [Migration Guide](https://github.com/laravel/vite-plugin/blob/main/UPGRADE.md#migrating-from-laravel-mix-to-vite) and automated by the [Vite Converter](https://laravelshift.com/convert-laravel-mix-to-vite).

**Before merging**, you need to:

- Checkout the `shift-80107` branch
- Run `composer update`
- Run `npm install`
- Review **all** comments for additional changes 
- Thoroughly test your application ([no tests?](https://laravelshift.com/laravel-test-generator), [no CI?](https://laravelshift.com/ci-generator))

Please send your feedback to shift@laravelshift.com or share the good vibes on [Twitter](https://twitter.com/laravelshift).
